### PR TITLE
Run measures in user script dirs

### DIFF
--- a/plugin/openstudio/lib/PluginUserScript.rb
+++ b/plugin/openstudio/lib/PluginUserScript.rb
@@ -59,5 +59,26 @@ class ReportingUserScript
   end
 end
 
+end #Ruleset
+module Measure
+
+class ModelMeasure
+  def registerWithApplication
+    Plugin.user_script_runner.add_user_script(self)
+  end
 end
+
+class EnergyPlusMeasure
+  def registerWithApplication
+    Plugin.user_script_runner.add_user_script(self)
+  end
+end
+
+class ReportingMeasure
+  def registerWithApplication
+    Plugin.user_script_runner.add_user_script(self)
+  end
+end
+
+end #Measure
 end

--- a/plugin/openstudio/lib/PluginUserScriptRunner.rb
+++ b/plugin/openstudio/lib/PluginUserScriptRunner.rb
@@ -355,16 +355,13 @@ module OpenStudio
 
       weather_file = @model_workflow_json.weatherFile
       if (not weather_file.empty?)
-        puts "weather_file #{weather_file}"
         @workflow.setWeatherFile(weather_file.get)
       end
 
       @working_files_dir = @working_dir / OpenStudio::toPath("generated_files")
-      puts "path #{@working_files_dir}"
       @workflow.addFilePath(@working_files_dir)
 
       @model_workflow_json.absoluteFilePaths().each do |file_path|
-        puts "path #{file_path}"
         @workflow.addFilePath(file_path)
       end
 

--- a/plugin/openstudio/lib/PluginUserScriptRunner.rb
+++ b/plugin/openstudio/lib/PluginUserScriptRunner.rb
@@ -296,6 +296,7 @@ module OpenStudio
       dirs.each do |dir|
         next if /resource[s]?/i.match(dir)
         next if /test[s]?/i.match(dir)
+        next if /doc[s]?/i.match(dir)
 
         menu = current_menu.add_submenu(File.basename(dir))
         discover_user_script_directory(dir, menu)
@@ -364,11 +365,11 @@ module OpenStudio
       #SKETCHUP_CONSOLE.show
 
       arguments = nil
-      if user_script.is_a?(OpenStudio::Ruleset::ModelUserScript)
+      if user_script.is_a?(OpenStudio::Ruleset::ModelUserScript) or user_script.is_a?(OpenStudio::Measure::ModelMeasure)
         arguments = user_script.arguments(model_interface.openstudio_model)
       end
 
-      if user_script.is_a?(OpenStudio::Ruleset::ReportingUserScript)
+      if user_script.is_a?(OpenStudio::Ruleset::ReportingUserScript) or user_script.is_a?(OpenStudio::Measure::ReportingMeasure)
         arguments = user_script.arguments()
       end
 
@@ -384,9 +385,9 @@ module OpenStudio
 
           error_msg += "Running #{user_script.name}\n"
 
-          if user_script.is_a?(OpenStudio::Ruleset::ModelUserScript)
+          if user_script.is_a?(OpenStudio::Ruleset::ModelUserScript) or user_script.is_a?(OpenStudio::Measure::ModelMeasure)
             user_script.run(model_interface.openstudio_model, self, arguments)
-          elsif user_script.is_a?(OpenStudio::Ruleset::ReportingUserScript)
+          elsif user_script.is_a?(OpenStudio::Ruleset::ReportingUserScript) or user_script.is_a?(OpenStudio::Measure::ReportingMeasure)
             user_script.run(self, arguments)
           end
 


### PR DESCRIPTION
This PR allows a user to paste OpenStudio Measures into their SketchUp Plug-in's user script directory (e.g. `C:\Users\macumber\AppData\Roaming\SketchUp\SketchUp 2022\SketchUp\Plugins\openstudio\user_scripts`).  The measure can then be run using `Extensions->OpenStudio User Scripts`